### PR TITLE
Update create-k8-patch to handle multiple consumers

### DIFF
--- a/github.yml
+++ b/github.yml
@@ -48,7 +48,7 @@ commands:
         type: env_var_name
       k8-container-name:
         default: K8_CONTAINER_NAME
-        description: Kubernetes container name
+        description: Kubernetes container names. Can be comma-separated list for adding multiple services.
         type: string
       add-consumer:
         default: false
@@ -61,11 +61,7 @@ commands:
     steps:
     - run:
         command: |
-            if [ $CIRCLE_TAG ]; then TAG_TYPE=$CIRCLE_TAG; else TAG_TYPE=$CIRCLE_SHA1; fi            
-            if [ "<<parameters.image>>" == "" ]
-              then IMAGE_NAME=<<parameters.k8-container-name>>
-              else IMAGE_NAME=<<parameters.image>>
-            fi
+            # Clone and checkout repo
             hub config --global credential.https://github.com.helper /usr/local/bin/hub-credential-helper
             hub config --global hub.protocol https
             hub config --global user.email $<<parameters.github-email>>
@@ -73,42 +69,63 @@ commands:
             hub clone "$<<parameters.github-owner>>/<<parameters.github-repo>>"
             cd <<parameters.github-repo>>
             hub checkout $<<parameters.github-branch>>
-            cat \<<EOF > patch.yaml
+
+            # Set value for the name of the image
+            if [ "<<parameters.image>>" == "" ]
+              then IMAGE_NAME="<<parameters.k8-container-name>>"
+              else IMAGE_NAME=<<parameters.image>>
+            fi
+            
+            # Determine tag for image, may be git tag or commit sha
+            if [ $CIRCLE_TAG ]; then TAG_TYPE=$CIRCLE_TAG; else TAG_TYPE=$CIRCLE_SHA1; fi            
+            
+            # Split image into array of containers (if passed as comma separated string)
+            IFS=', ' read -r -a CONTAINERS \<<< "<<parameters.k8-container-name>>"
+
+            # Add a separate service for each container
+            for CONTAINER in "${CONTAINERS[@]}"
+            do
+                echo "Adding patch for container: $CONTAINER"
+                # Create and commit patch to infrastructure repo service yaml
+                cat \<<EOF > patch.yaml
             spec:
               template:
                 spec:
                   containers:
-                    - name: <<parameters.k8-container-name>>
+                    - name: $CONTAINER
                       image: gcr.io/$<<parameters.google-project-id>>/${IMAGE_NAME}:${TAG_TYPE}
             EOF
-            if <<parameters.add-consumer>>
-            then cat \<<EOF >> patch.yaml
-                    - name: <<parameters.k8-container-name>>-consumer
+              if <<parameters.add-consumer>>
+              then cat \<<EOF >> patch.yaml
+                    - name: "$CONTAINER"-consumer
                       image: gcr.io/$<<parameters.google-project-id>>/${IMAGE_NAME}-consumer:${TAG_TYPE}
             EOF
-            fi
-            kubectl patch --local -o yaml \
-              -f kubernetes/deployments/<<parameters.k8-container-name>>.yaml \
-              -p "$(cat patch.yaml)" \
-              > <<parameters.k8-container-name>>.yaml
-            mv <<parameters.k8-container-name>>.yaml kubernetes/deployments/<<parameters.k8-container-name>>.yaml
-            hub add kubernetes/deployments/<<parameters.k8-container-name>>.yaml
+                fi
+                kubectl patch --local -o yaml \
+                  -f kubernetes/deployments/$CONTAINER.yaml \
+                  -p "$(cat patch.yaml)" \
+                  > $CONTAINER.yaml
+                mv $CONTAINER.yaml kubernetes/deployments/$CONTAINER.yaml
+                hub add kubernetes/deployments/$CONTAINER.yaml
+            done ## End for loop
 
+            # Build commit image string
             COMMIT_IMAGES=$"gcr.io/$<<parameters.google-project-id>>/${IMAGE_NAME}:${TAG_TYPE}"
-            if <<parameters.add-consumer>>
-            then COMMIT_IMAGES+=$'\n  '
-            COMMIT_IMAGES+=$"gcr.io/$<<parameters.google-project-id>>/${IMAGE_NAME}-consumer:${TAG_TYPE}."
+            if <<parameters.add-consumer>>; then
+              COMMIT_IMAGES+=$'\n  '
+              COMMIT_IMAGES+=$"gcr.io/$<<parameters.google-project-id>>/${IMAGE_NAME}-consumer:${TAG_TYPE}."
             fi
-  
             hub commit -F- \<<EOF
-            Update the <<parameters.k8-container-name>> application
-            This commit updates the <<parameters.k8-container-name>> deployment container image to:
-              $COMMIT_IMAGES
-            Build ID: ${CIRCLE_BUILD_NUM}
+                  Update the $CONTAINER application
+                  This commit updates the $CONTAINER container image to:
+                    $COMMIT_IMAGES
+                  Build ID: ${CIRCLE_BUILD_NUM}
             EOF
-            
+
+            # Push the comitted patches
             hub push origin $<<parameters.github-branch>>
-        name: Generate kubernetes patch yaml file and push to infrastructure repo
+
+        name: Generate kubernetes patch yaml files and push to infrastructure repo
 description: |
   An orb for working with Github. View this orb's source: https://github.com/carecloud-devops/orbs
 examples:
@@ -179,7 +196,7 @@ jobs:
         type: env_var_name
       k8-container-name:
         default: K8_CONTAINER_NAME
-        description: Kubernetes Container Name
+        description: Kubernetes container names. Can be comma-separated list for adding multiple services.
         type: string
       add-consumer:
         default: false


### PR DESCRIPTION
Consumers can be passed in as comma-separated string and will have their own deployment. Faster/less code than calling create-k8-patch multiple times in a row.

Promote carecloud/github@dev:latest